### PR TITLE
Delete export script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           yarn install
           yarn build
-          yarn export
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
https://github.com/Gamez0/dobin-resume/actions/runs/9803974971/job/27070970508
Reason: `next export` has been removed in favor of 'output: export' in next.config.js.
